### PR TITLE
Add btc.chaintools.io to Block Explorers section

### DIFF
--- a/bitcoin.html
+++ b/bitcoin.html
@@ -306,6 +306,7 @@
             <li><a href="https://chain.so/" target="_blank">SoChain</a></li>
             <li><a href="https://www.walletexplorer.com/" target="_blank">Wallet Explorer</a></li>
             <li><a href="http://yogh.io/" target="_blank">Yogh.io</a> - raw data block explorer</li>
+            <li><a href="https://btc.chaintools.io/" target="_blank">btc.chaintools.io</a> - open-source, RPC-driven</li>
           </ul>
           <br>
           <h3>Visualizations:</h3>


### PR DESCRIPTION
Clean, simple, RPC-driven explorer intended for node operators.